### PR TITLE
fix: specifying tcp keepalive to close server-side open streams

### DIFF
--- a/dnstt.go
+++ b/dnstt.go
@@ -244,6 +244,17 @@ func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTri
 		Proxy: func(*http.Request) (*url.URL, error) {
 			return url.Parse("http://127.0.0.1:8080") // dummy to force request to be sent correctly
 		},
+		// A persistent TLS session cache allows session resumption (TLS 1.3
+		// PSK / TLS 1.2 session tickets) for subsequent connections to the
+		// same host. Without this, every smux stream requires a full TLS
+		// handshake (~7-9 DNS round trips for the server Certificate alone at
+		// 135-byte MTU). With session resumption, subsequent handshakes are
+		// 1-RTT (~200ms) instead of ~8s, which is critical for redirect chains
+		// where each hop to the same host otherwise triggers a fresh handshake
+		// that exceeds many upstream servers' TLS negotiation timeouts.
+		TLSClientConfig: &tls.Config{
+			ClientSessionCache: tls.NewLRUClientSessionCache(64),
+		},
 	}
 	// resetSession closes the current smux session so that the next
 	// getStream call creates a new one with a clean KCP state.

--- a/dnstt.go
+++ b/dnstt.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -194,11 +193,11 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 		if err == nil {
 			return stream, nil
 		}
-		if !errors.Is(err, smux.ErrGoAway) {
-			return nil, fmt.Errorf("opening stream: %w", err)
-		}
-		// the session stream id overflowed, so we need to create a new session
-		slog.Debug("session stream id overflowed, closing current session")
+		// Any stream-open error (ErrGoAway = ID overflow, or a broken
+		// session) means this session is done. Close it so the next
+		// maybeCreateSession call builds a fresh KCP/smux session instead
+		// of retrying on the same broken one.
+		slog.Debug("closing broken session", "err", err)
 		d.sess.Close()
 	}
 	err = d.maybeCreateSession()
@@ -213,26 +212,13 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 	return stream, nil
 }
 
-// maxRoundTripRetries is the number of times a request is retried when the
-// tunnel returns a premature EOF (e.g. when the upstream server times out
-// the TLS handshake before the DNS tunnel completes it).
-const maxRoundTripRetries = 5
-
-// retryBaseDelay is the starting backoff duration before the first retry.
-// Each subsequent retry doubles the delay (capped at retryMaxDelay), with
-// ±25% random jitter applied to avoid synchronized retries.
-const retryBaseDelay = 500 * time.Millisecond
-
-// retryMaxDelay caps the exponential backoff to avoid very long waits.
-const retryMaxDelay = 5 * time.Second
-
 // NewRoundTripper creates a new HTTP round tripper for the given address.
 // It manages session creation and reuse.
 func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
 	if d.isClosed() {
 		return nil, errors.New("dnstt is closed")
 	}
-	inner := &http.Transport{
+	return &http.Transport{
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 			stream, err := d.getStream()
 			if err != nil {
@@ -255,99 +241,7 @@ func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTri
 		TLSClientConfig: &tls.Config{
 			ClientSessionCache: tls.NewLRUClientSessionCache(64),
 		},
-	}
-	// resetSession closes the current smux session so that the next
-	// getStream call creates a new one with a clean KCP state.
-	resetSession := func() {
-		d.sessAccess.Lock()
-		if d.sess != nil {
-			d.sess.Close()
-		}
-		d.sessAccess.Unlock()
-	}
-	return &retryRoundTripper{inner: inner, maxRetries: maxRoundTripRetries, resetSession: resetSession}, nil
-}
-
-// retryRoundTripper wraps an http.Transport and retries requests that fail with
-// a premature EOF or tunnel timeout. This can happen when an upstream server
-// (e.g. Cloudflare) times out a slow TLS handshake before the DNS tunnel has
-// finished delivering all the data. On retry the DoH connection is already
-// warm, so the tunnel is faster and the handshake succeeds.
-//
-// When a context deadline or timeout fires (degraded KCP session), resetSession
-// is called before the retry so the next attempt gets a fresh KCP/Noise session.
-type retryRoundTripper struct {
-	inner        *http.Transport
-	maxRetries   int
-	resetSession func() // closes the current session; next retry creates a fresh one
-}
-
-func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	var lastErr error
-	for attempt := 0; attempt <= r.maxRetries; attempt++ {
-		if attempt > 0 {
-			if req.Body != nil && req.GetBody == nil {
-				// Cannot replay a streaming request body; give up.
-				return nil, lastErr
-			}
-
-			// Exponential backoff with ±25% jitter: gives the DoH
-			// connections time to warm up before the next attempt.
-			delay := retryBaseDelay * (1 << (attempt - 1))
-			if delay > retryMaxDelay {
-				delay = retryMaxDelay
-			}
-			jitter := time.Duration(rand.Int63n(int64(delay) / 2))
-			if rand.Intn(2) == 0 {
-				delay += jitter
-			} else {
-				delay -= jitter
-			}
-			slog.Debug("retrying request after tunnel EOF", "attempt", attempt, "error", lastErr, "backoff", delay)
-			select {
-			case <-time.After(delay):
-			case <-req.Context().Done():
-				return nil, req.Context().Err()
-			}
-
-			r.inner.CloseIdleConnections()
-			if req.GetBody != nil {
-				body, err := req.GetBody()
-				if err != nil {
-					return nil, fmt.Errorf("retrying request body: %w", err)
-				}
-				req.Body = body
-			}
-		}
-		resp, err := r.inner.RoundTrip(req)
-		if err == nil {
-			return resp, nil
-		}
-		if !isTunnelEOF(err) {
-			return nil, err
-		}
-		// If the stream timed out, the KCP session may be degraded.
-		// Reset it so the next retry gets a fresh session with a clean state.
-		if isNetTimeout(err) && r.resetSession != nil {
-			slog.Debug("stream timeout — resetting KCP session before retry", "attempt", attempt)
-			r.resetSession()
-		}
-		lastErr = err
-	}
-	return nil, lastErr
-}
-
-// isTunnelEOF returns true when err represents a retryable tunnel failure:
-// a premature EOF (upstream server closed the connection before the DNS tunnel
-// finished delivering all data) or a net timeout (e.g. context deadline).
-func isTunnelEOF(err error) bool {
-	return errors.Is(err, io.EOF) || isNetTimeout(err)
-}
-
-// isNetTimeout returns true when err is (or wraps) a net.Error with Timeout.
-func isNetTimeout(err error) bool {
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
+	}, nil
 }
 
 // Option is a function type used to configure the dnstt instance.

--- a/dnstt.go
+++ b/dnstt.go
@@ -54,8 +54,8 @@ type dnstt struct {
 	sessAccess sync.Mutex
 	closed     atomic.Bool
 
-	pconn net.PacketConn
-	convID  uint32
+	pconn  net.PacketConn
+	convID uint32
 }
 
 // NewDNSTT creates a new DNSTT instance with the provided options. If no options are provided for
@@ -214,8 +214,8 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 }
 
 // maxRoundTripRetries is the number of times a request is retried when the
-// tunnel returns a premature EOF or timeout (e.g. when the upstream server
-// times out the TLS handshake before the DNS tunnel completes it).
+// tunnel returns a premature EOF (e.g. when the upstream server times out
+// the TLS handshake before the DNS tunnel completes it).
 const maxRoundTripRetries = 5
 
 // retryBaseDelay is the starting backoff duration before the first retry.
@@ -225,13 +225,6 @@ const retryBaseDelay = 500 * time.Millisecond
 
 // retryMaxDelay caps the exponential backoff to avoid very long waits.
 const retryMaxDelay = 5 * time.Second
-
-// streamTimeout is the per-stream deadline on the client side. It acts as a
-// safety net for a degraded KCP session: if nothing happens on a stream for
-// this long, the stream is closed with a timeout error, the session is reset,
-// and a fresh session is started on the next retry. Normal Cloudflare TLS
-// timeouts (~10s) fire well before this deadline.
-const streamTimeout = 30 * time.Second
 
 // NewRoundTripper creates a new HTTP round tripper for the given address.
 // It manages session creation and reuse.
@@ -245,11 +238,7 @@ func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTri
 			if err != nil {
 				return nil, fmt.Errorf("creating stream: %w", err)
 			}
-			slog.Debug(fmt.Sprintf("begin stream %08x:%d", d.convID, stream.ID()))
-			// Safety-net deadline: if the KCP session becomes degraded and
-			// stalls for longer than streamTimeout, the stream times out so
-			// the retrier can reset the session and start fresh.
-			stream.SetDeadline(time.Now().Add(streamTimeout))
+			slog.DebugContext(ctx, "begin stream", slog.String("convID", fmt.Sprintf("%08x", d.convID)), slog.Uint64("streamID", uint64(stream.ID())))
 			return &conn{Stream: stream, sessID: d.convID}, nil
 		},
 		Proxy: func(*http.Request) (*url.URL, error) {
@@ -274,8 +263,8 @@ func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTri
 // finished delivering all the data. On retry the DoH connection is already
 // warm, so the tunnel is faster and the handshake succeeds.
 //
-// When a tunnel timeout fires (KCP session degraded), resetSession is called
-// before the retry so the next attempt gets a fresh KCP/Noise session.
+// When a context deadline or timeout fires (degraded KCP session), resetSession
+// is called before the retry so the next attempt gets a fresh KCP/Noise session.
 type retryRoundTripper struct {
 	inner        *http.Transport
 	maxRetries   int
@@ -338,8 +327,8 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 // isTunnelEOF returns true when err represents a retryable tunnel failure:
-// a premature EOF (upstream server closed the connection) or a net timeout
-// (stream deadline fired because the KCP session was stalled).
+// a premature EOF (upstream server closed the connection before the DNS tunnel
+// finished delivering all data) or a net timeout (e.g. context deadline).
 func isTunnelEOF(err error) bool {
 	return errors.Is(err, io.EOF) || isNetTimeout(err)
 }

--- a/dnstt.go
+++ b/dnstt.go
@@ -119,6 +119,9 @@ func (d *dnstt) maybeCreateSession() (err error) {
 	if d.sess != nil && !d.sess.IsClosed() {
 		return nil
 	}
+	if d.pconn == nil {
+		return errors.New("no packet connection: transport dial may have failed")
+	}
 
 	// Open a KCP conn on the PacketConn.
 	conn, err := kcp.NewConn2(turbotunnel.DummyAddr{}, nil, 0, 0, d.pconn)
@@ -135,14 +138,16 @@ func (d *dnstt) maybeCreateSession() (err error) {
 	d.convID = conn.GetConv()
 	// Permit coalescing the payloads of consecutive sends.
 	conn.SetStreamMode(true)
-	// Disable the dynamic congestion window (limit only by the maximum of
-	// local and remote static windows).
-	conn.SetNoDelay(
-		0, // default nodelay
-		0, // default interval
-		0, // default resend
-		1, // nc=1 => congestion window off
-	)
+	// Tune KCP for low-latency interactive use over a high-delay DNS tunnel:
+	//   nodelay=1  → minimum RTO 30 ms (vs 100 ms default)
+	//   interval=10 → flush/retransmit tick every 10 ms
+	//   resend=2   → fast-retransmit after 2 duplicate ACKs
+	//   nc=1       → disable congestion window (window limited only by
+	//                the static send/recv window sizes set below)
+	conn.SetNoDelay(1, 10, 2, 1)
+	// Send ACKs immediately rather than batching them with the next
+	// 10 ms tick; this lets the remote side open its send window sooner.
+	conn.SetACKNoDelay(true)
 	conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
 	if !conn.SetMtu(d.mtu) {
 		return fmt.Errorf("setting MTU to %d", d.mtu)

--- a/dnstt.go
+++ b/dnstt.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -212,26 +213,141 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 	return stream, nil
 }
 
+// maxRoundTripRetries is the number of times a request is retried when the
+// tunnel returns a premature EOF or timeout (e.g. when the upstream server
+// times out the TLS handshake before the DNS tunnel completes it).
+const maxRoundTripRetries = 5
+
+// retryBaseDelay is the starting backoff duration before the first retry.
+// Each subsequent retry doubles the delay (capped at retryMaxDelay), with
+// ±25% random jitter applied to avoid synchronized retries.
+const retryBaseDelay = 500 * time.Millisecond
+
+// retryMaxDelay caps the exponential backoff to avoid very long waits.
+const retryMaxDelay = 5 * time.Second
+
+// streamTimeout is the per-stream deadline on the client side. It acts as a
+// safety net for a degraded KCP session: if nothing happens on a stream for
+// this long, the stream is closed with a timeout error, the session is reset,
+// and a fresh session is started on the next retry. Normal Cloudflare TLS
+// timeouts (~10s) fire well before this deadline.
+const streamTimeout = 30 * time.Second
+
 // NewRoundTripper creates a new HTTP round tripper for the given address.
 // It manages session creation and reuse.
 func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
 	if d.isClosed() {
 		return nil, errors.New("dnstt is closed")
 	}
-	rt := &http.Transport{
+	inner := &http.Transport{
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 			stream, err := d.getStream()
 			if err != nil {
 				return nil, fmt.Errorf("creating stream: %w", err)
 			}
 			slog.Debug(fmt.Sprintf("begin stream %08x:%d", d.convID, stream.ID()))
+			// Safety-net deadline: if the KCP session becomes degraded and
+			// stalls for longer than streamTimeout, the stream times out so
+			// the retrier can reset the session and start fresh.
+			stream.SetDeadline(time.Now().Add(streamTimeout))
 			return &conn{Stream: stream, sessID: d.convID}, nil
 		},
 		Proxy: func(*http.Request) (*url.URL, error) {
 			return url.Parse("http://127.0.0.1:8080") // dummy to force request to be sent correctly
 		},
 	}
-	return rt, nil
+	// resetSession closes the current smux session so that the next
+	// getStream call creates a new one with a clean KCP state.
+	resetSession := func() {
+		d.sessAccess.Lock()
+		if d.sess != nil {
+			d.sess.Close()
+		}
+		d.sessAccess.Unlock()
+	}
+	return &retryRoundTripper{inner: inner, maxRetries: maxRoundTripRetries, resetSession: resetSession}, nil
+}
+
+// retryRoundTripper wraps an http.Transport and retries requests that fail with
+// a premature EOF or tunnel timeout. This can happen when an upstream server
+// (e.g. Cloudflare) times out a slow TLS handshake before the DNS tunnel has
+// finished delivering all the data. On retry the DoH connection is already
+// warm, so the tunnel is faster and the handshake succeeds.
+//
+// When a tunnel timeout fires (KCP session degraded), resetSession is called
+// before the retry so the next attempt gets a fresh KCP/Noise session.
+type retryRoundTripper struct {
+	inner        *http.Transport
+	maxRetries   int
+	resetSession func() // closes the current session; next retry creates a fresh one
+}
+
+func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= r.maxRetries; attempt++ {
+		if attempt > 0 {
+			if req.Body != nil && req.GetBody == nil {
+				// Cannot replay a streaming request body; give up.
+				return nil, lastErr
+			}
+
+			// Exponential backoff with ±25% jitter: gives the DoH
+			// connections time to warm up before the next attempt.
+			delay := retryBaseDelay * (1 << (attempt - 1))
+			if delay > retryMaxDelay {
+				delay = retryMaxDelay
+			}
+			jitter := time.Duration(rand.Int63n(int64(delay) / 2))
+			if rand.Intn(2) == 0 {
+				delay += jitter
+			} else {
+				delay -= jitter
+			}
+			slog.Debug("retrying request after tunnel EOF", "attempt", attempt, "error", lastErr, "backoff", delay)
+			select {
+			case <-time.After(delay):
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+
+			r.inner.CloseIdleConnections()
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, fmt.Errorf("retrying request body: %w", err)
+				}
+				req.Body = body
+			}
+		}
+		resp, err := r.inner.RoundTrip(req)
+		if err == nil {
+			return resp, nil
+		}
+		if !isTunnelEOF(err) {
+			return nil, err
+		}
+		// If the stream timed out, the KCP session may be degraded.
+		// Reset it so the next retry gets a fresh session with a clean state.
+		if isNetTimeout(err) && r.resetSession != nil {
+			slog.Debug("stream timeout — resetting KCP session before retry", "attempt", attempt)
+			r.resetSession()
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// isTunnelEOF returns true when err represents a retryable tunnel failure:
+// a premature EOF (upstream server closed the connection) or a net timeout
+// (stream deadline fired because the KCP session was stalled).
+func isTunnelEOF(err error) bool {
+	return errors.Is(err, io.EOF) || isNetTimeout(err)
+}
+
+// isNetTimeout returns true when err is (or wraps) a net.Error with Timeout.
+func isNetTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // Option is a function type used to configure the dnstt instance.
@@ -416,11 +532,7 @@ func (c *conn) Write(b []byte) (int, error) {
 
 func (c *conn) Read(b []byte) (int, error) {
 	n, err := c.Stream.Read(b)
-	if err == io.EOF {
-		// smux Stream.Write may return io.EOF.
-		err = nil
-	}
-	if err != nil {
+	if err != nil && err != io.EOF {
 		id := fmt.Sprintf("%08x:%d", c.sessID, c.Stream.ID())
 		slog.Error("stream read error", "stream", id, "error", err)
 	}

--- a/dnstt.go
+++ b/dnstt.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -193,11 +194,11 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 		if err == nil {
 			return stream, nil
 		}
-		// Any stream-open error (ErrGoAway = ID overflow, or a broken
-		// session) means this session is done. Close it so the next
-		// maybeCreateSession call builds a fresh KCP/smux session instead
-		// of retrying on the same broken one.
-		slog.Debug("closing broken session", "err", err)
+		if !errors.Is(err, smux.ErrGoAway) {
+			return nil, fmt.Errorf("opening stream: %w", err)
+		}
+		// the session stream id overflowed, so we need to create a new session
+		slog.Debug("session stream id overflowed, closing current session")
 		d.sess.Close()
 	}
 	err = d.maybeCreateSession()
@@ -212,13 +213,26 @@ func (d *dnstt) getStream() (*smux.Stream, error) {
 	return stream, nil
 }
 
+// maxRoundTripRetries is the number of times a request is retried when the
+// tunnel returns a premature EOF (e.g. when the upstream server times out
+// the TLS handshake before the DNS tunnel completes it).
+const maxRoundTripRetries = 5
+
+// retryBaseDelay is the starting backoff duration before the first retry.
+// Each subsequent retry doubles the delay (capped at retryMaxDelay), with
+// ±25% random jitter applied to avoid synchronized retries.
+const retryBaseDelay = 500 * time.Millisecond
+
+// retryMaxDelay caps the exponential backoff to avoid very long waits.
+const retryMaxDelay = 5 * time.Second
+
 // NewRoundTripper creates a new HTTP round tripper for the given address.
 // It manages session creation and reuse.
 func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
 	if d.isClosed() {
 		return nil, errors.New("dnstt is closed")
 	}
-	return &http.Transport{
+	inner := &http.Transport{
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 			stream, err := d.getStream()
 			if err != nil {
@@ -241,7 +255,99 @@ func (d *dnstt) NewRoundTripper(ctx context.Context, addr string) (http.RoundTri
 		TLSClientConfig: &tls.Config{
 			ClientSessionCache: tls.NewLRUClientSessionCache(64),
 		},
-	}, nil
+	}
+	// resetSession closes the current smux session so that the next
+	// getStream call creates a new one with a clean KCP state.
+	resetSession := func() {
+		d.sessAccess.Lock()
+		if d.sess != nil {
+			d.sess.Close()
+		}
+		d.sessAccess.Unlock()
+	}
+	return &retryRoundTripper{inner: inner, maxRetries: maxRoundTripRetries, resetSession: resetSession}, nil
+}
+
+// retryRoundTripper wraps an http.Transport and retries requests that fail with
+// a premature EOF or tunnel timeout. This can happen when an upstream server
+// (e.g. Cloudflare) times out a slow TLS handshake before the DNS tunnel has
+// finished delivering all the data. On retry the DoH connection is already
+// warm, so the tunnel is faster and the handshake succeeds.
+//
+// When a context deadline or timeout fires (degraded KCP session), resetSession
+// is called before the retry so the next attempt gets a fresh KCP/Noise session.
+type retryRoundTripper struct {
+	inner        *http.Transport
+	maxRetries   int
+	resetSession func() // closes the current session; next retry creates a fresh one
+}
+
+func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= r.maxRetries; attempt++ {
+		if attempt > 0 {
+			if req.Body != nil && req.GetBody == nil {
+				// Cannot replay a streaming request body; give up.
+				return nil, lastErr
+			}
+
+			// Exponential backoff with ±25% jitter: gives the DoH
+			// connections time to warm up before the next attempt.
+			delay := retryBaseDelay * (1 << (attempt - 1))
+			if delay > retryMaxDelay {
+				delay = retryMaxDelay
+			}
+			jitter := time.Duration(rand.Int63n(int64(delay) / 2))
+			if rand.Intn(2) == 0 {
+				delay += jitter
+			} else {
+				delay -= jitter
+			}
+			slog.Debug("retrying request after tunnel EOF", "attempt", attempt, "error", lastErr, "backoff", delay)
+			select {
+			case <-time.After(delay):
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+
+			r.inner.CloseIdleConnections()
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, fmt.Errorf("retrying request body: %w", err)
+				}
+				req.Body = body
+			}
+		}
+		resp, err := r.inner.RoundTrip(req)
+		if err == nil {
+			return resp, nil
+		}
+		if !isTunnelEOF(err) {
+			return nil, err
+		}
+		// If the stream timed out, the KCP session may be degraded.
+		// Reset it so the next retry gets a fresh session with a clean state.
+		if isNetTimeout(err) && r.resetSession != nil {
+			slog.Debug("stream timeout — resetting KCP session before retry", "attempt", attempt)
+			r.resetSession()
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// isTunnelEOF returns true when err represents a retryable tunnel failure:
+// a premature EOF (upstream server closed the connection before the DNS tunnel
+// finished delivering all data) or a net timeout (e.g. context deadline).
+func isTunnelEOF(err error) bool {
+	return errors.Is(err, io.EOF) || isNetTimeout(err)
+}
+
+// isNetTimeout returns true when err is (or wraps) a net.Error with Timeout.
+func isNetTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // Option is a function type used to configure the dnstt instance.

--- a/dnstt.go
+++ b/dnstt.go
@@ -323,6 +323,14 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		if err == nil {
 			return resp, nil
 		}
+		// A deadline or cancellation on the caller's context must not be
+		// treated as a tunnel failure: *url.Error wrapping
+		// context.DeadlineExceeded satisfies net.Error.Timeout(), which
+		// would otherwise trigger resetSession() and disrupt every
+		// concurrent RoundTrip sharing the same smux session.
+		if req.Context().Err() != nil {
+			return nil, req.Context().Err()
+		}
 		if !isTunnelEOF(err) {
 			return nil, err
 		}

--- a/dnstt_test.go
+++ b/dnstt_test.go
@@ -1,13 +1,13 @@
 package dnstt
 
 import (
-	"bytes"
 	"context"
-	"errors"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	utls "github.com/refraction-networking/utls"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +22,8 @@ type mockTransport struct {
 
 func (m *mockTransport) dial(hello *utls.ClientHelloID) (net.PacketConn, error) {
 	args := m.Called(hello)
-	return args.Get(0).(net.PacketConn), args.Error(1)
+	conn, _ := args.Get(0).(net.PacketConn)
+	return conn, args.Error(1)
 }
 
 func (m *mockTransport) String() string {
@@ -35,22 +36,26 @@ func TestNewDNSTT(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test default ClientHelloID
-	dtt, err := NewDNSTT(WithDoH("https://example.com"))
+	dtt, err := NewDNSTT(WithDoH("https://example.com"), WithTunnelDomain("t.iantem.io"))
 	assert.NoError(t, err)
 	assert.NotNil(t, dtt)
 	assert.NotNil(t, dtt.(*dnstt).clientHelloID)
 }
 
 func TestDNSTT_NewRoundTripper(t *testing.T) {
-	mockTransport := &mockTransport{}
-	mockTransport.On("dial", mock.Anything).Return(nil, errors.New("dial error"))
+	// NewRoundTripper is lazy — it does not dial eagerly. When the underlying
+	// packet connection was never established (pconn == nil), the error surfaces
+	// only when RoundTrip is called.
+	d := &dnstt{}
 
-	dnstt := &dnstt{
-		transport: mockTransport,
-	}
-	_, err := dnstt.NewRoundTripper(context.Background(), "example.com")
+	rt, err := d.NewRoundTripper(context.Background(), "example.com")
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(req)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dial error")
 }
 
 func TestRoundTripperE2E(t *testing.T) {

--- a/dnstt_test.go
+++ b/dnstt_test.go
@@ -1,13 +1,12 @@
 package dnstt
 
 import (
+	"bytes"
 	"context"
-	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	utls "github.com/refraction-networking/utls"
 	"github.com/stretchr/testify/assert"

--- a/server/main.go
+++ b/server/main.go
@@ -307,6 +307,9 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 			}
 			return err
 		}
+		if err := stream.SetDeadline(time.Now().Add(kcpWriteTimeout)); err != nil {
+			log.Printf("failed to set stream deadline: %v", err)
+		}
 		log.Printf("begin stream %08x:%d", conn.GetConv(), stream.ID())
 		go func() {
 			defer func() {
@@ -343,6 +346,7 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int) error {
 			0, // default resend
 			1, // nc=1 => congestion window off
 		)
+		conn.SetDeadline(time.Now().Add(kcpWriteTimeout))
 		conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
 		if rc := conn.SetMtu(mtu); !rc {
 			panic(rc)

--- a/server/main.go
+++ b/server/main.go
@@ -45,6 +45,17 @@ const (
 	// https://dnsencryption.info/imc19-doe.html Section 4.2, Finding 2.4
 	maxResponseDelay = 1 * time.Second
 
+	// Number of sendLoop goroutines to run concurrently. Each goroutine
+	// holds one DNS response open (for up to maxResponseDelay) to bundle
+	// downstream packets into it before sending. More goroutines allow
+	// more queries to be served in parallel: each active client sends up
+	// to 16 concurrent polls (client-side pollLimit), so this value should
+	// comfortably exceed the expected number of simultaneous clients × 16.
+	// The receive channel (same capacity) absorbs bursts beyond this limit;
+	// excess queries are dropped by recvLoop (non-blocking send) and retried
+	// by the client. Goroutine overhead is negligible (~8 KB stack each).
+	numSendLoops = 100
+
 	// How long to wait for a TCP connection to upstream to be established.
 	upstreamDialTimeout = 30 * time.Second
 
@@ -867,13 +878,13 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 		}
 	}()
 
-	ch := make(chan *record, 100)
+	ch := make(chan *record, numSendLoops)
 	defer close(ch)
 
 	// We could run multiple copies of sendLoop; that would allow more time
 	// for each response to collect downstream data before being evicted by
 	// another response that needs to be sent.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < numSendLoops; i++ {
 		go func() {
 			err := sendLoop(dnsConn, ttConn, ch, maxEncodedPayload)
 			if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -215,9 +215,9 @@ func handleStream(stream *smux.Stream, conv uint32) error {
 	// safety net on platforms where these syscalls are unsupported.
 	if tc, ok := targetConn.(*net.TCPConn); ok {
 		if err := tc.SetKeepAlive(true); err != nil {
-			log.Printf("stream %08x:%d: SetKeepAlive: %v", conv, stream.ID(), err)
+			slog.Warn("SetKeepAlive failed", slog.String("conv", fmt.Sprintf("%08x", conv)), slog.Any("stream_id", stream.ID()), slog.Any("err", err))
 		} else if err := tc.SetKeepAlivePeriod(upstreamKeepalivePeriod); err != nil {
-			log.Printf("stream %08x:%d: SetKeepAlivePeriod: %v", conv, stream.ID(), err)
+			slog.Warn("SetKeepAlivePeriod failed", slog.String("conv", fmt.Sprintf("%08x", conv)), slog.Any("stream_id", stream.ID()), slog.Any("err", err))
 		}
 	}
 
@@ -308,17 +308,17 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 			return err
 		}
 		if err := stream.SetDeadline(time.Now().Add(kcpWriteTimeout)); err != nil {
-			log.Printf("failed to set stream deadline: %v", err)
+			slog.Warn("failed to set stream deadline", slog.Any("err", err))
 		}
-		log.Printf("begin stream %08x:%d", conn.GetConv(), stream.ID())
+		slog.Info("begin stream", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("stream_id", stream.ID()))
 		go func() {
 			defer func() {
-				log.Printf("end stream %08x:%d", conn.GetConv(), stream.ID())
+				slog.Info("end stream", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("stream_id", stream.ID()))
 				stream.Close()
 			}()
 			err := handleStream(stream, conn.GetConv())
 			if err != nil {
-				log.Printf("stream %08x:%d handleStream: %v", conn.GetConv(), stream.ID(), err)
+				slog.Error("handleStream failed", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("stream_id", stream.ID()), slog.Any("err", err))
 			}
 		}()
 	}
@@ -335,7 +335,7 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int) error {
 			}
 			return err
 		}
-		log.Printf("begin session %08x", conn.GetConv())
+		slog.Info("begin session", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())))
 		// Permit coalescing the payloads of consecutive sends.
 		conn.SetStreamMode(true)
 		// Disable the dynamic congestion window (limit only by the
@@ -346,19 +346,20 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int) error {
 			0, // default resend
 			1, // nc=1 => congestion window off
 		)
-		conn.SetDeadline(time.Now().Add(kcpWriteTimeout))
+		conn.SetReadDeadline(time.Now().Add(kcpReadTimeout))
+		conn.SetWriteDeadline(time.Now().Add(kcpWriteTimeout))
 		conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
 		if rc := conn.SetMtu(mtu); !rc {
 			panic(rc)
 		}
 		go func() {
 			defer func() {
-				log.Printf("end session %08x", conn.GetConv())
+				slog.Info("end session", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())))
 				conn.Close()
 			}()
 			err := acceptStreams(conn, privkey)
 			if err != nil && !errors.Is(err, io.ErrClosedPipe) {
-				log.Printf("session %08x acceptStreams: %v", conn.GetConv(), err)
+				slog.Error("acceptStreams failed", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("err", err))
 			}
 		}()
 	}
@@ -435,7 +436,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 			// "If a query message with more than one OPT RR is
 			// received, a FORMERR (RCODE=1) MUST be returned."
 			resp.Flags |= dns.RcodeFormatError
-			log.Printf("FORMERR: more than one OPT RR")
+			slog.Warn("FORMERR: more than one OPT RR")
 			return resp, nil
 		}
 		resp.Additional = append(resp.Additional, dns.RR{
@@ -455,7 +456,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 			// RCODE=BADVERS."
 			resp.Flags |= dns.ExtendedRcodeBadVers & 0xf
 			additional.TTL = (dns.ExtendedRcodeBadVers >> 4) << 24
-			log.Printf("BADVERS: EDNS version %d != 0", version)
+			slog.Warn("BADVERS: unsupported EDNS version", slog.Any("version", version))
 			return resp, nil
 		}
 
@@ -472,7 +473,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	// There must be exactly one question.
 	if len(query.Question) != 1 {
 		resp.Flags |= dns.RcodeFormatError
-		log.Printf("FORMERR: too few or too many questions (%d)", len(query.Question))
+		slog.Warn("FORMERR: unexpected question count", slog.Any("count", len(query.Question)))
 		return resp, nil
 	}
 	question := query.Question[0]
@@ -484,7 +485,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	if !ok {
 		// Not a name we are authoritative for.
 		resp.Flags |= dns.RcodeNameError
-		log.Printf("NXDOMAIN: not authoritative for %s", question.Name)
+		slog.Warn("NXDOMAIN: not authoritative", slog.Any("name", question.Name))
 		return resp, nil
 	}
 	resp.Flags |= 0x0400 // AA = 1
@@ -492,7 +493,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	if query.Opcode() != 0 {
 		// We don't support OPCODE != QUERY.
 		resp.Flags |= dns.RcodeNotImplemented
-		log.Printf("NOTIMPL: unrecognized OPCODE %d", query.Opcode())
+		slog.Warn("NOTIMPL: unrecognized OPCODE", slog.Any("opcode", query.Opcode()))
 		return resp, nil
 	}
 
@@ -513,7 +514,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	if err != nil {
 		// Base32 error, make like the name doesn't exist.
 		resp.Flags |= dns.RcodeNameError
-		log.Printf("NXDOMAIN: base32 decoding: %v", err)
+		slog.Warn("NXDOMAIN: base32 decoding error", slog.Any("err", err))
 		return resp, nil
 	}
 	payload = payload[:n]
@@ -526,7 +527,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	// FORMERR MUST be returned."
 	if payloadSize < maxUDPPayload {
 		resp.Flags |= dns.RcodeFormatError
-		log.Printf("FORMERR: requester payload size %d is too small (minimum %d)", payloadSize, maxUDPPayload)
+		slog.Warn("FORMERR: requester payload too small", slog.Any("payload_size", payloadSize), slog.Any("minimum", maxUDPPayload))
 		return resp, nil
 	}
 
@@ -554,7 +555,7 @@ func recvLoop(domain dns.Name, dnsConn net.PacketConn, ttConn *turbotunnel.Queue
 		n, addr, err := dnsConn.ReadFrom(buf[:])
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Temporary() {
-				log.Printf("ReadFrom temporary error: %v", err)
+				slog.Warn("ReadFrom temporary error", slog.Any("err", err))
 				continue
 			}
 			return err
@@ -563,7 +564,7 @@ func recvLoop(domain dns.Name, dnsConn net.PacketConn, ttConn *turbotunnel.Queue
 		// Got a UDP packet. Try to parse it as a DNS message.
 		query, err := dns.MessageFromWireFormat(buf[:n])
 		if err != nil {
-			log.Printf("cannot parse DNS query: %v", err)
+			slog.Warn("cannot parse DNS query", slog.Any("err", err))
 			continue
 		}
 
@@ -588,7 +589,7 @@ func recvLoop(domain dns.Name, dnsConn net.PacketConn, ttConn *turbotunnel.Queue
 			// Payload is not long enough to contain a ClientID.
 			if resp != nil && resp.Rcode() == dns.RcodeNoError {
 				resp.Flags |= dns.RcodeNameError
-				log.Printf("NXDOMAIN: %d bytes are too short to contain a ClientID", n)
+				slog.Warn("NXDOMAIN: payload too short for ClientID", slog.Any("bytes", n))
 			}
 		}
 		// If a response is called for, pass it to sendLoop via the channel.
@@ -703,13 +704,13 @@ func sendLoop(dnsConn net.PacketConn, ttConn *turbotunnel.QueuePacketConn, ch <-
 
 		buf, err := rec.Resp.WireFormat()
 		if err != nil {
-			log.Printf("resp WireFormat: %v", err)
+			slog.Error("resp WireFormat error", slog.Any("err", err))
 			continue
 		}
 		// Truncate if necessary.
 		// https://tools.ietf.org/html/rfc1035#section-4.1.1
 		if len(buf) > maxUDPPayload {
-			log.Printf("truncating response of %d bytes to max of %d", len(buf), maxUDPPayload)
+			slog.Debug("truncating response", slog.Any("size", len(buf)), slog.Any("max", maxUDPPayload))
 			buf = buf[:maxUDPPayload]
 			buf[2] |= 0x02 // TC = 1
 		}
@@ -718,7 +719,7 @@ func sendLoop(dnsConn net.PacketConn, ttConn *turbotunnel.QueuePacketConn, ch <-
 		_, err = dnsConn.WriteTo(buf, rec.Addr)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Temporary() {
-				log.Printf("WriteTo temporary error: %v", err)
+				slog.Warn("WriteTo temporary error", slog.Any("err", err))
 				continue
 			}
 			return err
@@ -889,7 +890,7 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 	go func() {
 		err := acceptSessions(ln, privkey, mtu)
 		if err != nil {
-			log.Printf("acceptSessions: %v", err)
+			slog.Error("acceptSessions error", slog.Any("err", err))
 		}
 	}()
 
@@ -903,7 +904,7 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 		go func() {
 			err := sendLoop(dnsConn, ttConn, ch, maxEncodedPayload)
 			if err != nil {
-				log.Printf("sendLoop: %v", err)
+				slog.Error("sendLoop error", slog.Any("err", err))
 			}
 		}()
 	}
@@ -914,7 +915,7 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 func startPprof() {
 	go func() {
 		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
-			log.Printf("pprof server stopped: %v", err)
+			slog.Error("pprof server stopped", slog.Any("err", err))
 		}
 	}()
 }
@@ -946,7 +947,14 @@ Example:
 	flag.StringVar(&udpAddr, "udp", "", "UDP address to listen on (required)")
 	flag.Parse()
 
-	log.SetFlags(log.LstdFlags | log.LUTC)
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				a.Value = slog.TimeValue(a.Value.Time().UTC())
+			}
+			return a
+		},
+	})))
 
 	if genKey {
 		// -gen-key mode.
@@ -1015,8 +1023,8 @@ Example:
 			}
 		}
 		if len(privkey) == 0 {
-			log.Println("generating a temporary one-time keypair")
-			log.Println("use the -privkey or -privkey-file option for a persistent server keypair")
+			slog.Warn("generating a temporary one-time keypair")
+			slog.Warn("use the -privkey or -privkey-file option for a persistent server keypair")
 			var err error
 			privkey, err = noise.GeneratePrivkey()
 			if err != nil {
@@ -1031,7 +1039,8 @@ Example:
 		}
 		err = run(privkey, domain, dnsConn)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error("run failed", slog.Any("err", err))
+			os.Exit(1)
 		}
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -245,6 +245,9 @@ func handleStream(stream *smux.Stream, conv uint32) error {
 		}
 	}
 
+	// Clear the stream deadline before piping: the request phase is done, so
+	// pipeData can run for as long as the upstream connection is alive.
+	stream.SetDeadline(time.Time{})
 	pipeData(stream, targetConn)
 	return nil
 }
@@ -261,15 +264,45 @@ func pipeData(stream, targetConn io.ReadWriteCloser) {
 	<-done // Wait for the stream to close.
 }
 
+// rollingDeadlineRW wraps a kcp.UDPSession and resets read/write deadlines on
+// every I/O call. This ensures:
+//   - Reads time out if no data arrives within kcpReadTimeout (detects a stalled
+//     session where the client has silently disappeared and stopped querying).
+//   - Writes time out within kcpWriteTimeout if the client's KCP receive window
+//     is full (i.e. the client has stopped ACKing), which lets smux keepalive
+//     failures surface quickly instead of blocking indefinitely.
+type rollingDeadlineRW struct {
+	conn         *kcp.UDPSession
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+func (r *rollingDeadlineRW) Read(b []byte) (int, error) {
+	r.conn.SetReadDeadline(time.Now().Add(r.readTimeout))
+	return r.conn.Read(b)
+}
+
+func (r *rollingDeadlineRW) Write(b []byte) (int, error) {
+	r.conn.SetWriteDeadline(time.Now().Add(r.writeTimeout))
+	return r.conn.Write(b)
+}
+
+func (r *rollingDeadlineRW) Close() error {
+	return r.conn.Close()
+}
+
 // acceptStreams wraps a KCP session in a Noise channel and an smux.Session,
 // then awaits smux streams. It passes each stream to handleStream.
 func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
-	// Put a Noise channel on top of the KCP conn.
-	// Wrap conn with a per-write deadline so that smux keepalive writes fail
-	// fast when the client stops ACKing, rather than blocking indefinitely.
-	rw, err := noise.NewServer(conn, privkey)
+	// Put a Noise channel on top of the KCP conn, wrapped in rolling per-op
+	// deadlines so that a silently-disappeared client is detected promptly.
+	rw, err := noise.NewServer(&rollingDeadlineRW{
+		conn:         conn,
+		readTimeout:  kcpReadTimeout,
+		writeTimeout: kcpWriteTimeout,
+	}, privkey)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create noise connection: %w", err)
 	}
 
 	// Put an smux session on top of the encrypted Noise channel.
@@ -279,7 +312,7 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 	smuxConfig.MaxStreamBuffer = 1 * 1024 * 1024 // default is 65536
 	sess, err := smux.Server(rw, smuxConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 	defer sess.Close()
 
@@ -289,9 +322,13 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 			if err, ok := err.(net.Error); ok && err.Temporary() {
 				continue
 			}
-			return err
+			return fmt.Errorf("failed to accept stream: %w", err)
 		}
-		if err := stream.SetDeadline(time.Now().Add(kcpWriteTimeout)); err != nil {
+		// Bound the initial request phase: if the client opens a stream but
+		// never sends an HTTP request, this deadline kills it after kcpReadTimeout.
+		// handleStream clears this deadline before starting pipeData, so active
+		// connections are not capped by an absolute stream lifetime.
+		if err := stream.SetDeadline(time.Now().Add(kcpReadTimeout)); err != nil {
 			slog.Warn("failed to set stream deadline", slog.Any("err", err))
 		}
 		slog.Info("begin stream", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("stream_id", stream.ID()))
@@ -322,16 +359,14 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int) error {
 		slog.Info("begin session", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())))
 		// Permit coalescing the payloads of consecutive sends.
 		conn.SetStreamMode(true)
-		// Disable the dynamic congestion window (limit only by the
-		// maximum of local and remote static windows).
-		conn.SetNoDelay(
-			0, // default nodelay
-			0, // default interval
-			0, // default resend
-			1, // nc=1 => congestion window off
-		)
-		conn.SetReadDeadline(time.Now().Add(kcpReadTimeout))
-		conn.SetWriteDeadline(time.Now().Add(kcpWriteTimeout))
+		// Tune KCP for low-latency interactive use over a high-delay DNS tunnel:
+		//   nodelay=1  → minimum RTO 30 ms (vs 100 ms default)
+		//   interval=10 → flush/retransmit tick every 10 ms
+		//   resend=2   → fast-retransmit after 2 duplicate ACKs
+		//   nc=1       → disable congestion window
+		conn.SetNoDelay(1, 10, 2, 1)
+		// Send ACKs immediately rather than batching them with the next tick.
+		conn.SetACKNoDelay(true)
 		conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
 		if rc := conn.SetMtu(mtu); !rc {
 			panic(rc)
@@ -600,6 +635,7 @@ func sendLoop(dnsConn net.PacketConn, ttConn *turbotunnel.QueuePacketConn, ch <-
 			var ok bool
 			rec, ok = <-ch
 			if !ok {
+				slog.Warn("got a invalid record, breaking sendloop")
 				break
 			}
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -901,8 +901,15 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 }
 
 func startPprof() {
+	pprofDebug := strings.TrimSpace(os.Getenv("PPROF_DEBUG"))
+	if pprofDebug == "" || pprofDebug == "0" || strings.EqualFold(pprofDebug, "false") {
+		return
+	}
+
 	go func() {
-		_ = http.ListenAndServe("127.0.0.1:6060", nil)
+		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+			log.Printf("pprof server stopped: %v", err)
+		}
 	}()
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -62,6 +62,7 @@ const (
 	// which writes a ping every 10 s — will fail fast rather than blocking
 	// indefinitely, allowing smux to detect and close the dead session.
 	kcpWriteTimeout = 30 * time.Second
+	kcpReadTimeout  = 60 * time.Second
 )
 
 var (
@@ -249,41 +250,13 @@ func pipeData(stream, targetConn io.ReadWriteCloser) {
 	<-done // Wait for the stream to close.
 }
 
-// writeTimeoutConn wraps a net.Conn and enforces a per-write deadline.
-//
-// Without this, smux keepalive writes can block indefinitely once the KCP
-// send-window fills up — which happens when a client disappears and stops
-// ACKing. The blocked write prevents smux from ever reaching its
-// KeepAliveTimeout check, so dead sessions are never reaped and their
-// pipeData goroutines accumulate.
-//
-// By timing out each write individually, a failed write propagates through
-// Noise → smux immediately, causing smux to close the session and unblock
-// all associated streams.
-type writeTimeoutConn struct {
-	net.Conn
-	timeout time.Duration
-}
-
-func (c *writeTimeoutConn) Write(b []byte) (int, error) {
-	if err := c.Conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
-		return 0, err
-	}
-	// Always clear the deadline on exit — whether Write succeeds, returns a
-	// partial write, or times out — so a stale past-deadline never bleeds
-	// into the next call. Errors from clearing are ignored: if the connection
-	// is already broken, the error from Write is the one that matters.
-	defer c.Conn.SetWriteDeadline(time.Time{})
-	return c.Conn.Write(b)
-}
-
 // acceptStreams wraps a KCP session in a Noise channel and an smux.Session,
 // then awaits smux streams. It passes each stream to handleStream.
 func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 	// Put a Noise channel on top of the KCP conn.
 	// Wrap conn with a per-write deadline so that smux keepalive writes fail
 	// fast when the client stops ACKing, rather than blocking indefinitely.
-	rw, err := noise.NewServer(&writeTimeoutConn{conn, kcpWriteTimeout}, privkey)
+	rw, err := noise.NewServer(conn, privkey)
 	if err != nil {
 		return err
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -879,7 +879,7 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 	}
 
 	// Start up the virtual PacketConn for turbotunnel.
-	ttConn := turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, idleTimeout*2)
+	ttConn := turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, idleTimeout)
 	ln, err := kcp.ServeConn(nil, 0, 0, ttConn)
 	if err != nil {
 		return fmt.Errorf("opening KCP listener: %v", err)
@@ -899,12 +899,14 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 	// We could run multiple copies of sendLoop; that would allow more time
 	// for each response to collect downstream data before being evicted by
 	// another response that needs to be sent.
-	go func() {
-		err := sendLoop(dnsConn, ttConn, ch, maxEncodedPayload)
-		if err != nil {
-			log.Printf("sendLoop: %v", err)
-		}
-	}()
+	for i := 0; i < 10; i++ {
+		go func() {
+			err := sendLoop(dnsConn, ttConn, ch, maxEncodedPayload)
+			if err != nil {
+				log.Printf("sendLoop: %v", err)
+			}
+		}()
+	}
 
 	return recvLoop(domain, dnsConn, ttConn, ch)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -210,9 +210,15 @@ func handleStream(stream *smux.Stream, conv uint32) error {
 	// Enable TCP keepalives so the OS can detect and close connections to
 	// upstream targets that stop responding without sending FIN/RST. Without
 	// this, a hung server holds the pipeData goroutines open indefinitely.
+	// Keepalives are best-effort: log failures but do not abort the stream,
+	// since the proxy still works correctly; it just loses the early-detection
+	// safety net on platforms where these syscalls are unsupported.
 	if tc, ok := targetConn.(*net.TCPConn); ok {
-		tc.SetKeepAlive(true)
-		tc.SetKeepAlivePeriod(upstreamKeepalivePeriod)
+		if err := tc.SetKeepAlive(true); err != nil {
+			log.Printf("stream %08x:%d: SetKeepAlive: %v", conv, stream.ID(), err)
+		} else if err := tc.SetKeepAlivePeriod(upstreamKeepalivePeriod); err != nil {
+			log.Printf("stream %08x:%d: SetKeepAlivePeriod: %v", conv, stream.ID(), err)
+		}
 	}
 
 	if req.Method == "CONNECT" {
@@ -263,13 +269,12 @@ func (c *writeTimeoutConn) Write(b []byte) (int, error) {
 	if err := c.Conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
 		return 0, err
 	}
-	n, err := c.Conn.Write(b)
-	if err == nil {
-		// Reset the deadline so a slow-but-alive session isn't penalised
-		// across calls; each write gets a fresh window.
-		c.Conn.SetWriteDeadline(time.Time{})
-	}
-	return n, err
+	// Always clear the deadline on exit — whether Write succeeds, returns a
+	// partial write, or times out — so a stale past-deadline never bleeds
+	// into the next call. Errors from clearing are ignored: if the connection
+	// is already broken, the error from Write is the one that matters.
+	defer c.Conn.SetWriteDeadline(time.Time{})
+	return c.Conn.Write(b)
 }
 
 // acceptStreams wraps a KCP session in a Noise channel and an smux.Session,

--- a/server/main.go
+++ b/server/main.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"strings"
@@ -846,6 +847,12 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 	return recvLoop(domain, dnsConn, ttConn, ch)
 }
 
+func startPprof() {
+	go func() {
+		_ = http.ListenAndServe("127.0.0.1:6060", nil)
+	}()
+}
+
 func main() {
 	var genKey bool
 	var privkeyFilename string
@@ -952,6 +959,7 @@ Example:
 			}
 		}
 
+		startPprof()
 		err = run(privkey, domain, dnsConn)
 		if err != nil {
 			log.Fatal(err)

--- a/server/main.go
+++ b/server/main.go
@@ -51,10 +51,16 @@ const (
 	// more queries to be served in parallel: each active client sends up
 	// to 16 concurrent polls (client-side pollLimit), so this value should
 	// comfortably exceed the expected number of simultaneous clients × 16.
-	// The receive channel (same capacity) absorbs bursts beyond this limit;
-	// excess queries are dropped by recvLoop (non-blocking send) and retried
-	// by the client. Goroutine overhead is negligible (~8 KB stack each).
+	// Goroutine overhead is negligible (~8 KB stack each).
 	numSendLoops = 100
+
+	// Size of the channel that feeds records from recvLoop to the sendLoop
+	// goroutines. Sized well above numSendLoops so that recvLoop's
+	// non-blocking send (default: drop) does not lose records during bursts
+	// where all numSendLoops goroutines are busy holding a response open for
+	// up to maxResponseDelay. A drop means the client's DNS query goes
+	// unanswered, slowing downstream delivery until the next poll.
+	sendLoopChanSize = numSendLoops * 10
 
 	// How long to wait for a TCP connection to upstream to be established.
 	upstreamDialTimeout = 30 * time.Second
@@ -72,8 +78,19 @@ const (
 	// this deadline enforced on every write, the smux keepalive goroutine —
 	// which writes a ping every 10 s — will fail fast rather than blocking
 	// indefinitely, allowing smux to detect and close the dead session.
-	kcpWriteTimeout = 30 * time.Second
-	kcpReadTimeout  = 60 * time.Second
+	// kcpWriteTimeout is the per-op write deadline on the KCP session. It
+	// must be large enough to survive a full KCP send window filling up
+	// while the client is busy doing a slow TLS handshake over DNS. DNS
+	// round trips are ~200ms and a TLS Certificate can be 3-8KB, so
+	// ~22+ DNS trips for the cert alone ≈ 4-5s. With KCP congestion window
+	// disabled (nc=1) and smux keepalives at 10s, 120s gives plenty of
+	// margin for the application data phase without pinning zombie sessions.
+	kcpWriteTimeout = 120 * time.Second
+	// kcpReadTimeout is the per-op read deadline on the KCP session. If no
+	// data arrives for this long, the client has silently disappeared. Must
+	// be larger than the longest possible idle gap (client-side poll
+	// backs off to maxPollDelay=10s, so 120s is comfortably above that).
+	kcpReadTimeout = 120 * time.Second
 )
 
 var (
@@ -185,7 +202,18 @@ func readKeyFromFile(filename string) ([]byte, error) {
 
 // handleStream acts as a basic HTTP proxy, connecting a client stream to the requested HTTP target.
 func handleStream(stream *smux.Stream, conv uint32) error {
-	req, err := http.ReadRequest(bufio.NewReader(stream))
+	// Set the deadline now (inside the goroutine) so the clock starts
+	// when the goroutine is actually running, not before it is scheduled.
+	if err := stream.SetDeadline(time.Now().Add(kcpReadTimeout)); err != nil {
+		slog.Warn("failed to set stream deadline", slog.Any("err", err))
+	}
+
+	// Use a single bufio.Reader for the entire lifetime of this stream.
+	// http.ReadRequest may pre-fetch bytes beyond the request headers into
+	// the buffer; we must pass the same reader to pipeData so those bytes
+	// are not silently dropped when we copy client→target data.
+	br := bufio.NewReader(stream)
+	req, err := http.ReadRequest(br)
 	if err != nil {
 		return fmt.Errorf("stream %08x:%d HTTP request read: %v", conv, stream.ID(), err)
 	}
@@ -248,17 +276,29 @@ func handleStream(stream *smux.Stream, conv uint32) error {
 	// Clear the stream deadline before piping: the request phase is done, so
 	// pipeData can run for as long as the upstream connection is alive.
 	stream.SetDeadline(time.Time{})
-	pipeData(stream, targetConn)
+	pipeData(stream, br, targetConn)
 	return nil
 }
 
-func pipeData(stream, targetConn io.ReadWriteCloser) {
+// pipeData bidirectionally copies between the smux stream and the upstream TCP
+// connection. br must be the same bufio.Reader used by http.ReadRequest so that
+// any bytes pre-fetched into its buffer are not lost.
+//
+// We drain br's internal buffer first (via io.CopyN), then copy the raw stream
+// directly. We deliberately avoid io.Copy(targetConn, br) because
+// bufio.Reader implements io.WriterTo, and WriteTo unconditionally calls
+// targetConn.Write(empty) before filling its buffer — a 0-byte write that
+// blocks forever on net.Pipe connections and stalls in production.
+func pipeData(stream io.ReadWriteCloser, br *bufio.Reader, targetConn io.ReadWriteCloser) {
 	done := make(chan struct{})
 	go func() {
 		io.Copy(stream, targetConn)
 		stream.Close()
 		close(done)
 	}()
+	if n := br.Buffered(); n > 0 {
+		io.CopyN(targetConn, br, int64(n)) //nolint:errcheck
+	}
 	io.Copy(targetConn, stream)
 	targetConn.Close()
 	<-done // Wait for the stream to close.
@@ -323,13 +363,6 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 				continue
 			}
 			return fmt.Errorf("failed to accept stream: %w", err)
-		}
-		// Bound the initial request phase: if the client opens a stream but
-		// never sends an HTTP request, this deadline kills it after kcpReadTimeout.
-		// handleStream clears this deadline before starting pipeData, so active
-		// connections are not capped by an absolute stream lifetime.
-		if err := stream.SetDeadline(time.Now().Add(kcpReadTimeout)); err != nil {
-			slog.Warn("failed to set stream deadline", slog.Any("err", err))
 		}
 		slog.Info("begin stream", slog.String("conv", fmt.Sprintf("%08x", conn.GetConv())), slog.Any("stream_id", stream.ID()))
 		go func() {
@@ -914,7 +947,7 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 		}
 	}()
 
-	ch := make(chan *record, numSendLoops)
+	ch := make(chan *record, sendLoopChanSize)
 	defer close(ch)
 
 	// We could run multiple copies of sendLoop; that would allow more time

--- a/server/main.go
+++ b/server/main.go
@@ -47,6 +47,13 @@ const (
 
 	// How long to wait for a TCP connection to upstream to be established.
 	upstreamDialTimeout = 30 * time.Second
+
+	// How frequently to send TCP keepalive probes to upstream targets. The OS
+	// closes the connection after a system-dependent number of missed probes
+	// (typically ~9 on Linux with the default 75 s probe interval, so ~11 min
+	// total). A short period here means a hung upstream is detected and the
+	// pipeData goroutines unblocked much sooner.
+	upstreamKeepalivePeriod = 30 * time.Second
 )
 
 var (
@@ -192,6 +199,13 @@ func handleStream(stream *smux.Stream, conv uint32) error {
 		return fmt.Errorf("stream %08x:%d connect target %s: %v", conv, stream.ID(), targetAddr, err)
 	}
 	defer targetConn.Close()
+	// Enable TCP keepalives so the OS can detect and close connections to
+	// upstream targets that stop responding without sending FIN/RST. Without
+	// this, a hung server holds the pipeData goroutines open indefinitely.
+	if tc, ok := targetConn.(*net.TCPConn); ok {
+		tc.SetKeepAlive(true)
+		tc.SetKeepAlivePeriod(upstreamKeepalivePeriod)
+	}
 
 	if req.Method == "CONNECT" {
 		// HTTP tunnel

--- a/server/main.go
+++ b/server/main.go
@@ -906,11 +906,6 @@ func run(privkey []byte, domain dns.Name, dnsConn net.PacketConn) error {
 }
 
 func startPprof() {
-	pprofDebug := strings.TrimSpace(os.Getenv("PPROF_DEBUG"))
-	if pprofDebug == "" || pprofDebug == "0" || strings.EqualFold(pprofDebug, "false") {
-		return
-	}
-
 	go func() {
 		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
 			log.Printf("pprof server stopped: %v", err)
@@ -1024,7 +1019,10 @@ Example:
 			}
 		}
 
-		startPprof()
+		pprofDebug := strings.TrimSpace(os.Getenv("PPROF_DEBUG"))
+		if pprofDebug != "" && pprofDebug != "0" && !strings.EqualFold(pprofDebug, "false") {
+			startPprof()
+		}
 		err = run(privkey, domain, dnsConn)
 		if err != nil {
 			log.Fatal(err)

--- a/server/main.go
+++ b/server/main.go
@@ -54,6 +54,14 @@ const (
 	// total). A short period here means a hung upstream is detected and the
 	// pipeData goroutines unblocked much sooner.
 	upstreamKeepalivePeriod = 30 * time.Second
+
+	// How long a single KCP write may block before the session is considered
+	// dead. Writes stall when the remote client stops ACKing (KCP send-window
+	// full), which is the main symptom of a silently-disappeared client. With
+	// this deadline enforced on every write, the smux keepalive goroutine —
+	// which writes a ping every 10 s — will fail fast rather than blocking
+	// indefinitely, allowing smux to detect and close the dead session.
+	kcpWriteTimeout = 30 * time.Second
 )
 
 var (
@@ -235,11 +243,42 @@ func pipeData(stream, targetConn io.ReadWriteCloser) {
 	<-done // Wait for the stream to close.
 }
 
+// writeTimeoutConn wraps a net.Conn and enforces a per-write deadline.
+//
+// Without this, smux keepalive writes can block indefinitely once the KCP
+// send-window fills up — which happens when a client disappears and stops
+// ACKing. The blocked write prevents smux from ever reaching its
+// KeepAliveTimeout check, so dead sessions are never reaped and their
+// pipeData goroutines accumulate.
+//
+// By timing out each write individually, a failed write propagates through
+// Noise → smux immediately, causing smux to close the session and unblock
+// all associated streams.
+type writeTimeoutConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *writeTimeoutConn) Write(b []byte) (int, error) {
+	if err := c.Conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	n, err := c.Conn.Write(b)
+	if err == nil {
+		// Reset the deadline so a slow-but-alive session isn't penalised
+		// across calls; each write gets a fresh window.
+		c.Conn.SetWriteDeadline(time.Time{})
+	}
+	return n, err
+}
+
 // acceptStreams wraps a KCP session in a Noise channel and an smux.Session,
 // then awaits smux streams. It passes each stream to handleStream.
 func acceptStreams(conn *kcp.UDPSession, privkey []byte) error {
 	// Put a Noise channel on top of the KCP conn.
-	rw, err := noise.NewServer(conn, privkey)
+	// Wrap conn with a per-write deadline so that smux keepalive writes fail
+	// fast when the client stops ACKing, rather than blocking indefinitely.
+	rw, err := noise.NewServer(&writeTimeoutConn{conn, kcpWriteTimeout}, privkey)
 	if err != nil {
 		return err
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -668,7 +668,7 @@ func sendLoop(dnsConn net.PacketConn, ttConn *turbotunnel.QueuePacketConn, ch <-
 			var ok bool
 			rec, ok = <-ch
 			if !ok {
-				slog.Warn("got a invalid record, breaking sendloop")
+				slog.Debug("closing sendLoop")
 				break
 			}
 		}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"net"
 	"runtime"
 	"testing"
@@ -19,7 +20,7 @@ func TestPipeDataExitsOnStreamClose(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		pipeData(stream, targetConn)
+		pipeData(stream, bufio.NewReader(stream), targetConn)
 		close(done)
 	}()
 
@@ -41,7 +42,7 @@ func TestPipeDataExitsOnTargetConnClose(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		pipeData(stream, targetConn)
+		pipeData(stream, bufio.NewReader(stream), targetConn)
 		close(done)
 	}()
 
@@ -92,7 +93,7 @@ func TestPipeDataExitsOnHungTarget(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		pipeData(stream, targetConn)
+		pipeData(stream, bufio.NewReader(stream), targetConn)
 		close(done)
 	}()
 
@@ -114,7 +115,7 @@ func TestPipeDataNoGoroutineLeak(t *testing.T) {
 		stream, streamPeer := net.Pipe()
 		targetConn, targetPeer := net.Pipe()
 
-		go pipeData(stream, targetConn)
+		go pipeData(stream, bufio.NewReader(stream), targetConn)
 
 		// Close both remote ends so pipeData drains immediately.
 		streamPeer.Close()

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"net"
 	"runtime"
 	"testing"
@@ -129,59 +128,33 @@ func TestPipeDataNoGoroutineLeak(t *testing.T) {
 		runtime.NumGoroutine(), baseline)
 }
 
-// TestWriteTimeoutConnTimesOut verifies that writeTimeoutConn returns a timeout
-// error when the remote peer stops consuming data — simulating a client that
-// has disappeared and left the KCP send-window full.
-func TestWriteTimeoutConnTimesOut(t *testing.T) {
-	// net.Pipe is synchronous: writes to 'a' block until 'b' reads.
-	// By not reading from 'b' we recreate the full-send-window condition.
+// TestStreamDeadlineBoundsGoroutine is the regression test for the dominant
+// goroutine leak: goroutines stuck waiting for data that never arrives.
+// acceptStreams calls stream.SetDeadline(kcpWriteTimeout) on every accepted
+// stream so that a parked goroutine is unblocked once the deadline fires —
+// verified here using a plain net.Pipe with the same deadline pattern.
+func TestStreamDeadlineBoundsGoroutine(t *testing.T) {
 	a, b := net.Pipe()
 	defer b.Close()
 
-	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
+	require.NoError(t, a.SetDeadline(time.Now().Add(150*time.Millisecond)))
 
-	_, err := wrapped.Write([]byte("data that will never be consumed"))
-	require.Error(t, err, "expected write to time out when reader is not consuming")
-	var netErr net.Error
-	require.ErrorAs(t, err, &netErr)
-	assert.True(t, netErr.Timeout(), "expected a timeout error, got: %v", err)
-}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 1024)
+		_, err := a.Read(buf)
+		require.Error(t, err)
+		var netErr net.Error
+		require.ErrorAs(t, err, &netErr)
+		assert.True(t, netErr.Timeout())
+	}()
 
-// TestWriteTimeoutConnClearsDeadlineAfterError verifies that the write deadline
-// is cleared even when Write returns an error (the case Copilot flagged).
-// Without the defer, a stale past-deadline would cause the next write to fail
-// immediately, even if the connection recovers from a transient error.
-func TestWriteTimeoutConnClearsDeadlineAfterError(t *testing.T) {
-	a, b := net.Pipe()
-	defer b.Close()
-
-	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
-
-	// First write times out because nobody is reading from b.
-	_, err := wrapped.Write([]byte("blocked"))
-	require.Error(t, err)
-
-	// Start consuming from b so the next write can succeed.
-	go io.Copy(io.Discard, b)
-
-	// If the deadline was not cleared after the error, this second write would
-	// fail immediately with a past-deadline error rather than succeeding.
-	_, err = wrapped.Write([]byte("should succeed now"))
-	assert.NoError(t, err, "write should succeed after deadline is cleared on error path")
-}
-
-// TestWriteTimeoutConnSucceedsNormally verifies that writeTimeoutConn does not
-// interfere with writes when the remote peer is actively reading.
-func TestWriteTimeoutConnSucceedsNormally(t *testing.T) {
-	a, b := net.Pipe()
-	defer a.Close()
-	defer b.Close()
-
-	go io.Copy(io.Discard, b) // consume everything written to a
-
-	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
-	_, err := wrapped.Write([]byte("hello"))
-	assert.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after stream deadline expired")
+	}
 }
 
 // TestUpstreamConnKeepaliveEnabled verifies that the TCP keepalive option is

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPipeDataExitsOnStreamClose verifies pipeData goroutines exit when the
+// smux stream side closes — the normal client-disconnect path.
+func TestPipeDataExitsOnStreamClose(t *testing.T) {
+	stream, streamPeer := net.Pipe()
+	targetConn, targetPeer := net.Pipe()
+	defer targetPeer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		pipeData(stream, targetConn)
+		close(done)
+	}()
+
+	streamPeer.Close() // client disconnects
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeData did not exit after stream close")
+	}
+}
+
+// TestPipeDataExitsOnTargetConnClose verifies pipeData exits when the upstream
+// target closes — e.g. the server finishes its response.
+func TestPipeDataExitsOnTargetConnClose(t *testing.T) {
+	stream, streamPeer := net.Pipe()
+	targetConn, targetPeer := net.Pipe()
+	defer streamPeer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		pipeData(stream, targetConn)
+		close(done)
+	}()
+
+	targetPeer.Close() // upstream closes
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeData did not exit after target close")
+	}
+}
+
+// TestPipeDataExitsOnHungTarget is the regression test for the goroutine leak.
+// It verifies that pipeData exits when the upstream connection stops responding
+// — the scenario TCP keepalives are designed to detect.
+//
+// In production, the OS fires a connection-level error once keepalive probes go
+// unanswered. We replicate that here by setting a read deadline, which produces
+// the same net.Error the OS-level closure generates.
+func TestPipeDataExitsOnHungTarget(t *testing.T) {
+	// A server that accepts but never writes — simulates a hung upstream.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(10 * time.Second) // hangs indefinitely
+	}()
+
+	targetConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+
+	// Simulate the OS closing the connection after keepalive probes fail.
+	// SetReadDeadline produces the same net.Error that an OS-level close does.
+	err = targetConn.(*net.TCPConn).SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	require.NoError(t, err)
+
+	stream, streamPeer := net.Pipe()
+	defer streamPeer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		pipeData(stream, targetConn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeData did not exit after hung target connection timed out")
+	}
+}
+
+// TestPipeDataNoGoroutineLeak verifies that goroutines do not accumulate across
+// many pipeData calls once connections close — the core property the keepalive
+// fix is meant to ensure.
+func TestPipeDataNoGoroutineLeak(t *testing.T) {
+	const n = 20
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < n; i++ {
+		stream, streamPeer := net.Pipe()
+		targetConn, targetPeer := net.Pipe()
+
+		go pipeData(stream, targetConn)
+
+		// Close both remote ends so pipeData drains immediately.
+		streamPeer.Close()
+		targetPeer.Close()
+	}
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+5
+	}, 5*time.Second, 10*time.Millisecond,
+		"goroutines did not drain after connections closed (current: %d, baseline: %d)",
+		runtime.NumGoroutine(), baseline)
+}
+
+// TestUpstreamConnKeepaliveEnabled verifies that the TCP keepalive option is
+// successfully applied to an upstream connection — i.e. both the type assertion
+// and the syscall succeed without error.
+func TestUpstreamConnKeepaliveEnabled(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		conn, _ := ln.Accept()
+		if conn != nil {
+			conn.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tc, ok := conn.(*net.TCPConn)
+	require.True(t, ok, "net.Dial returned a non-TCP conn")
+	assert.NoError(t, tc.SetKeepAlive(true))
+	assert.NoError(t, tc.SetKeepAlivePeriod(upstreamKeepalivePeriod))
+}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -144,6 +144,29 @@ func TestWriteTimeoutConnTimesOut(t *testing.T) {
 	assert.True(t, netErr.Timeout(), "expected a timeout error, got: %v", err)
 }
 
+// TestWriteTimeoutConnClearsDeadlineAfterError verifies that the write deadline
+// is cleared even when Write returns an error (the case Copilot flagged).
+// Without the defer, a stale past-deadline would cause the next write to fail
+// immediately, even if the connection recovers from a transient error.
+func TestWriteTimeoutConnClearsDeadlineAfterError(t *testing.T) {
+	a, b := net.Pipe()
+	defer b.Close()
+
+	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
+
+	// First write times out because nobody is reading from b.
+	_, err := wrapped.Write([]byte("blocked"))
+	require.Error(t, err)
+
+	// Start consuming from b so the next write can succeed.
+	go io.Copy(io.Discard, b)
+
+	// If the deadline was not cleared after the error, this second write would
+	// fail immediately with a past-deadline error rather than succeeding.
+	_, err = wrapped.Write([]byte("should succeed now"))
+	assert.NoError(t, err, "write should succeed after deadline is cleared on error path")
+}
+
 // TestWriteTimeoutConnSucceedsNormally verifies that writeTimeoutConn does not
 // interfere with writes when the remote peer is actively reading.
 func TestWriteTimeoutConnSucceedsNormally(t *testing.T) {

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net"
 	"runtime"
 	"testing"
@@ -123,6 +124,38 @@ func TestPipeDataNoGoroutineLeak(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond,
 		"goroutines did not drain after connections closed (current: %d, baseline: %d)",
 		runtime.NumGoroutine(), baseline)
+}
+
+// TestWriteTimeoutConnTimesOut verifies that writeTimeoutConn returns a timeout
+// error when the remote peer stops consuming data — simulating a client that
+// has disappeared and left the KCP send-window full.
+func TestWriteTimeoutConnTimesOut(t *testing.T) {
+	// net.Pipe is synchronous: writes to 'a' block until 'b' reads.
+	// By not reading from 'b' we recreate the full-send-window condition.
+	a, b := net.Pipe()
+	defer b.Close()
+
+	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
+
+	_, err := wrapped.Write([]byte("data that will never be consumed"))
+	require.Error(t, err, "expected write to time out when reader is not consuming")
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout(), "expected a timeout error, got: %v", err)
+}
+
+// TestWriteTimeoutConnSucceedsNormally verifies that writeTimeoutConn does not
+// interfere with writes when the remote peer is actively reading.
+func TestWriteTimeoutConnSucceedsNormally(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	go io.Copy(io.Discard, b) // consume everything written to a
+
+	wrapped := &writeTimeoutConn{a, 100 * time.Millisecond}
+	_, err := wrapped.Write([]byte("hello"))
+	assert.NoError(t, err)
 }
 
 // TestUpstreamConnKeepaliveEnabled verifies that the TCP keepalive option is

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -68,13 +68,16 @@ func TestPipeDataExitsOnHungTarget(t *testing.T) {
 	require.NoError(t, err)
 	defer ln.Close()
 
+	stop := make(chan struct{})
+	defer close(stop)
+
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
 		defer conn.Close()
-		time.Sleep(10 * time.Second) // hangs indefinitely
+		<-stop
 	}()
 
 	targetConn, err := net.Dial("tcp", ln.Addr().String())


### PR DESCRIPTION
This PR tries to fix the current issue with too many go routines left open awaiting for streaming requests from client by specifying a TCP keep-alive timeout. 

This PR also enable pprof in order to monitor and verify if the go routines are still broken

related to getlantern/engineering#3096